### PR TITLE
Use react-transform for hot module reloading on the web

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "web": {
+      "plugins": [
+        "react-transform"
+      ],
+      "extra": {
+        "react-transform": [{
+          "target": "react-transform-webpack-hmr",
+          "imports": ["react"],
+          "locals": ["module"]
+        }, {
+          "target": "react-transform-catch-errors",
+          "imports": ["react", "redbox-react"]
+        }]
+      }
+    }
+  },
+  "stage": 0
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
   </head>
   <body>
     <div id="main"></div>
-    <script src="build/bundle.web.js"></script>
+    <script src="/static/bundle.web.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,18 +5,26 @@
   "scripts": {
     "start": "echo \"Use 'npm run ios' or 'npm run web'\"; exit 1",
     "ios": "open iOS/WellnessDiary.xcodeproj & react-native-webpack-server start --webpackConfigPath ios.config.js",
-    "web": "webpack --config web.config.js -w & open index.html"
+    "web": "NODE_ENV=web babel-node server.web.js"
   },
   "dependencies": {
     "react": "^0.13.3",
     "react-native": "^0.10.1"
   },
   "devDependencies": {
+    "babel": "^5.8.23",
     "babel-core": "^5.8.24",
     "babel-loader": "^5.3.2",
+    "babel-plugin-react-transform": "^1.0.3",
+    "express": "^4.13.3",
     "react-hot-loader": "^1.3.0",
     "react-native-webpack-server": "^0.3.0",
+    "react-transform-catch-errors": "^0.1.2",
+    "react-transform-webpack-hmr": "^0.1.4",
+    "redbox-react": "^1.0.3",
     "webpack": "^1.12.1",
-    "webpack-dev-server": "^1.10.1"
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-dev-server": "^1.10.1",
+    "webpack-hot-middleware": "^2.0.1"
   }
 }

--- a/server.web.js
+++ b/server.web.js
@@ -1,0 +1,26 @@
+import path from 'path'
+import express from 'express'
+import webpack from 'webpack'
+import config from './web.config'
+
+const app = express()
+const compiler = webpack(config)
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  noInfo: true,
+  publicPath: config.output.publicPath
+}))
+
+app.use(require('webpack-hot-middleware')(compiler))
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'))
+})
+
+app.listen(3000, '0.0.0.0', (err) => {
+  if (err) {
+    console.log(err)
+    return
+  }
+  console.log('Listening at http://localhost:3000')
+})

--- a/web.config.js
+++ b/web.config.js
@@ -1,18 +1,25 @@
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'source-map',
-  entry: {
-    'bundle': [path.join(__dirname, 'src/main.web.js')],
-  },
+  devtool: 'eval',
+  entry: [
+    'webpack-hot-middleware/client',
+    path.join(__dirname, 'src/main.web.js')
+  ],
   output: {
-    path: path.join(__dirname, 'build'),
-    filename: '[name].web.js',
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.web.js',
+    publicPath: '/static/'
   },
   resolve: {
     root: path.join(__dirname, 'src'),
     extensions: ['', '.js', '.web', '.web.js']
   },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ],
   module: {
     loaders: [{
       test: /\.js/,


### PR DESCRIPTION
This runs a small server on `http://localhost:3000` with hot reloading for web based builds instead of just opening `index.html`. This is a good first step to universal/isomorphic javascript.  This will require another run of `npm install` as there are new deps.

Web builds are still run with a `npm run web`.

@NeverGoStable/owners Just need some :+1: or :-1: 

@tm507211 Think you could pull down this branch and test it out on your setup?